### PR TITLE
fixed socket.io logic and react keys

### DIFF
--- a/app/components/ChatList.jsx
+++ b/app/components/ChatList.jsx
@@ -16,7 +16,11 @@ class ChatList extends Component {
   render() {
 
     let messageDivs = this.state.messages.map((message) => {
-      return (<div className = "message">{message}</div>);
+      return (
+        <div key = {Math.floor(Math.random() * 1000)} className = "message">
+          {message}
+        </div>
+      );
     });
 
     return (

--- a/app/components/Index.jsx
+++ b/app/components/Index.jsx
@@ -10,7 +10,8 @@ class Index extends Component {
   constructor(props) {
     super(props);
     this.state = { online: 0 };
-    socket = io.connect(props.url);
+
+    socket = this.props.socket;
 
     socket.on('user:online', (numOnline) => {
       this.setState({ online: numOnline });

--- a/app/components/Index.jsx
+++ b/app/components/Index.jsx
@@ -1,7 +1,6 @@
 import ChatTextBox from './ChatTextBox.jsx';
 import  React, { Component } from 'react';
 import ChatList from './ChatList.jsx';
-import io from 'socket.io-client';
 
 let socket;
 

--- a/app/main.js
+++ b/app/main.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 const socket = io.connect();
 const ReactApp = require('./components/Index.jsx').default;
-const url = `${document.location.protocol}//${document.location.host}`;
 const mountNode = document.getElementById('react-root');
 
 ReactDOM.render(<ReactApp socket = {socket}/>, mountNode);

--- a/app/main.js
+++ b/app/main.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+const socket = io.connect();
 const ReactApp = require('./components/Index.jsx').default;
 const url = `${document.location.protocol}//${document.location.host}`;
 const mountNode = document.getElementById('react-root');
 
-ReactDOM.render(<ReactApp url = {url}/>, mountNode);
+ReactDOM.render(<ReactApp socket = {socket}/>, mountNode);

--- a/test/components/test_index.js
+++ b/test/components/test_index.js
@@ -18,7 +18,7 @@ describe('Index', function () {
   const client2 = io.connect(url, options);
 
   beforeEach(function () {
-    component = renderComponent(Index, { url });
+    component = renderComponent(Index, { socket: client1 });
   });
 
   it('should render on the page', () => {

--- a/views/index.jade
+++ b/views/index.jade
@@ -1,4 +1,5 @@
 html
+    script(src="/socket.io/socket.io.js")
     body
         div#container
             div(id='react-root')


### PR DESCRIPTION
Found out the `socket.io` server library automatically exposes the client side api, which is nice. So I removed the logic for trying to dynamically connect the client side by getting the url via js. Now it's just a simple `io.connect()`.

I also _temporarily_ fixed the keys error shown in the console by the React library. This is not a good solution though because it's just a random number from 1-1000 attached to the message div.. so an actual unique key must be figured out to uniquely identify each message for the React DOM.
